### PR TITLE
[INF-8310] filter generated TXT records when deleting to avoid deleti…

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -43,6 +43,9 @@ type TXTRegistry struct {
 	recordsCacheRefreshTime time.Time
 	cacheInterval           time.Duration
 
+	// cache the txt records in memory to avoid deleting one that doesn't actually exists
+	txtRecordsCache []*endpoint.Endpoint
+
 	// optional string to use to replace the asterisk in wildcard entries - without using this,
 	// registry TXT records corresponding to wildcard records will be invalid (and rejected by most providers), due to
 	// having a '*' appear (not as the first character) - see https://tools.ietf.org/html/rfc1034#section-4.3.3
@@ -95,6 +98,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 	}
 
 	endpoints := []*endpoint.Endpoint{}
+	txtEndpoints := []*endpoint.Endpoint{}
 
 	labelMap := map[string]endpoint.Labels{}
 
@@ -103,6 +107,8 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 			endpoints = append(endpoints, record)
 			continue
 		}
+		txtEndpoints = append(txtEndpoints, record)
+
 		// We simply assume that TXT records for the registry will always have only one target.
 		labels, err := endpoint.NewLabelsFromString(record.Targets[0])
 		if err == endpoint.ErrInvalidHeritage {
@@ -142,6 +148,7 @@ func (im *TXTRegistry) Records(ctx context.Context) ([]*endpoint.Endpoint, error
 		im.recordsCache = endpoints
 		im.recordsCacheRefreshTime = time.Now()
 	}
+	im.txtRecordsCache = txtEndpoints
 
 	return endpoints, nil
 }
@@ -191,6 +198,9 @@ func (im *TXTRegistry) ApplyChanges(ctx context.Context, changes *plan.Changes) 
 			im.removeFromCache(r)
 		}
 	}
+
+	// this avoids trying to delete records that are already gone
+	filteredChanges.Delete = im.filterExistingRecords(filteredChanges.Delete)
 
 	// make sure TXT records are consistently updated as well
 	for _, r := range filteredChanges.UpdateOld {
@@ -396,4 +406,20 @@ func (im *TXTRegistry) removeFromCache(ep *endpoint.Endpoint) {
 			return
 		}
 	}
+}
+
+func (im *TXTRegistry) filterExistingRecords(records []*endpoint.Endpoint) []*endpoint.Endpoint {
+	filtered := []*endpoint.Endpoint{}
+	for _, r := range records {
+		if r.RecordType != endpoint.RecordTypeTXT {
+			filtered = append(filtered, r)
+			continue
+		}
+		for _, t := range im.txtRecordsCache {
+			if r.DNSName == t.DNSName && r.SetIdentifier == t.SetIdentifier {
+				filtered = append(filtered, r)
+			}
+		}
+	}
+	return filtered
 }

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -388,30 +388,22 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	ctxEndpoints := []*endpoint.Endpoint{}
 	ctx := context.WithValue(context.Background(), provider.RecordsContextKey, ctxEndpoints)
 	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
-		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
+		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
 	}
-	p.ApplyChanges(ctx, &plan.Changes{
+	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
+	err := r.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.cname-tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("multiple.test-zone.example.org", "lb1.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
-			newEndpointWithOwner("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-1"),
 			newEndpointWithOwner("multiple.test-zone.example.org", "lb2.loadbalancer.com", endpoint.RecordTypeCNAME, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("txt.multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
-			newEndpointWithOwner("txt.cname-multiple.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, "").WithSetIdentifier("test-set-2"),
 		},
 	})
-	r, _ := NewTXTRegistry(p, "txt.", "", "owner", time.Hour, "")
+	assert.NoError(t, err)
+	r.Records(ctx) // init txtRecordsCache
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -485,7 +477,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
 		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
 	}
-	err := r.ApplyChanges(ctx, changes)
+	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
 }
 
@@ -501,6 +493,7 @@ func testTXTRegistryApplyChangesWithTemplatedPrefix(t *testing.T) {
 		Create: []*endpoint.Endpoint{},
 	})
 	r, _ := NewTXTRegistry(p, "prefix%{record_type}.", "", "owner", time.Hour, "")
+	r.Records(ctx) // init txtRecordsCache
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
@@ -544,6 +537,7 @@ func testTXTRegistryApplyChangesWithTemplatedSuffix(t *testing.T) {
 		assert.Equal(t, ctxEndpoints, ctx.Value(provider.RecordsContextKey))
 	}
 	r, _ := NewTXTRegistry(p, "", "-%{record_type}suffix", "owner", time.Hour, "")
+	r.Records(ctx) // init txtRecordsCache
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwnerResource("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", endpoint.RecordTypeCNAME, "", "ingress/default/my-ingress"),
@@ -609,6 +603,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 		},
 	})
 	r, _ := NewTXTRegistry(p, "", "-txt", "owner", time.Hour, "wildcard")
+	r.Records(ctx) // init txtRecordsCache
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -684,7 +679,7 @@ func testTXTRegistryApplyChangesWithSuffix(t *testing.T) {
 			"Delete":    got.Delete,
 		}
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
-		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
+		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
 	}
 	err := r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
@@ -700,19 +695,24 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
+
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+	}
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	err := r.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+		},
+	})
+	assert.NoError(t, err)
+	r.Records(ctx) // init txtRecordsCache
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -762,7 +762,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
 		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
 	}
-	err := r.ApplyChanges(ctx, changes)
+	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
 }
 
@@ -865,19 +865,24 @@ func TestNewTXTScheme(t *testing.T) {
 	}
 	p.ApplyChanges(ctx, &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("cname-foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 		},
 	})
+
+	p.OnApplyChanges = func(ctx context.Context, got *plan.Changes) {
+		assert.Nil(t, ctx.Value(provider.RecordsContextKey))
+	}
 	r, _ := NewTXTRegistry(p, "", "", "owner", time.Hour, "")
+	err := r.ApplyChanges(ctx, &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+		},
+	})
+	assert.NoError(t, err)
+	r.Records(ctx) // init txtRecordsCache
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
@@ -927,7 +932,7 @@ func TestNewTXTScheme(t *testing.T) {
 		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
 		assert.Equal(t, nil, ctx.Value(provider.RecordsContextKey))
 	}
-	err := r.ApplyChanges(ctx, changes)
+	err = r.ApplyChanges(ctx, changes)
 	require.NoError(t, err)
 }
 
@@ -938,13 +943,13 @@ func TestGenerateTXT(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{},
+			Labels:     map[string]string{},
 		},
 		{
 			DNSName:    "cname-foo.test-zone.example.org",
 			Targets:    endpoint.Targets{"\"heritage=external-dns,external-dns/owner=owner\""},
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{},
+			Labels:     map[string]string{},
 		},
 	}
 	p := inmemory.NewInMemoryProvider()


### PR DESCRIPTION
**The issue**

During the reconciliation loop, at the time external-dns tries to apply changes route53 it has lost track of it's TXT entries. So when the it knows it needs to delete or update a CNAME/A entry it will do some guesswork to figure out which TXT entries are supposed to go with it.

For example if I need to delete a `CNAME` entry with name `foobar.test.org`, it knows there should be a `TXT` entry named `cname-foobar.test.org`.

This causes two issues:
* the TXT entry might already be gone (because someone deleted it manually through the AWS console)
* for route53, it loses tracks of which records are ALIAS or CNAME once the ingress is deleted, which leads to incorrect guesswork

**The solution**

I added a cache of txt that is initialized at the start of the reconciliation loop, when external-dns fetches records from the provider (in our case route53). When applying changes (at the end of the reconciliation loop), we use this cache to filter out TXT records that do not exist and avoid invalid request to the provider.

**The tests**

To handle this situation better, I changes a few tests to make sure initial data would go through the registry (which creates TXT entries) instead of the lower level provider. This can avoid testing with `TXT` records that wouldn't match what external-dns would have otherwise created.