### PR TITLE
[INF-8932] don't rely on txt-cache if we actually have to make changes

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -223,6 +223,12 @@ func (c *Controller) RunOnce(ctx context.Context) error {
 	plan = plan.Calculate()
 
 	if plan.Changes.HasChanges() {
+		// FIXME: this is terrible
+		// basically if we see that we are going to change something but we used the cache, we re-run the plan without the cache
+		if c.Registry.UsedCache() {
+			c.Registry.ClearCache()
+			return c.RunOnce(ctx)
+		}
 		err = c.Registry.ApplyChanges(ctx, plan.Changes)
 		if err != nil {
 			registryErrorsTotal.Inc()

--- a/registry/aws_sd_registry.go
+++ b/registry/aws_sd_registry.go
@@ -108,3 +108,11 @@ func (sdr *AWSSDRegistry) PropertyValuesEqual(name string, previous string, curr
 func (sdr *AWSSDRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
 	return sdr.provider.AdjustEndpoints(endpoints)
 }
+
+func (sdr *AWSSDRegistry) UsedCache() bool {
+	return false
+}
+
+func (sdr *AWSSDRegistry) ClearCache() {
+	return
+}

--- a/registry/noop.go
+++ b/registry/noop.go
@@ -64,3 +64,11 @@ func (im *NoopRegistry) PropertyValuesEqual(attribute string, previous string, c
 func (im *NoopRegistry) AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
 	return im.provider.AdjustEndpoints(endpoints)
 }
+
+func (im *NoopRegistry) UsedCache() bool {
+	return false
+}
+
+func (im *NoopRegistry) ClearCache() {
+	return
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -36,6 +36,8 @@ type Registry interface {
 	AdjustEndpoints(endpoints []*endpoint.Endpoint) []*endpoint.Endpoint
 	GetDomainFilter() endpoint.DomainFilterInterface
 	MissingRecords() []*endpoint.Endpoint
+	UsedCache() bool
+	ClearCache()
 }
 
 // TODO(ideahitme): consider moving this to Plan


### PR DESCRIPTION
The basic idea is that if we are planning to do changes based on a cached result, we clear the cache and re-plan the changes. This doesn't totally negate the effect of using a cache for txt records because most of the time we won't have any changes planned.

The bug it tries to avoid is the following:
* ext-dns starts and loads the txt records in its cache
* we modifies the heritage in the txt record
* at the next run, ext-dns doesn't fetch the modified record but uses the cache and still sees the unmodified heritage